### PR TITLE
Add libsodium and allow vendor libraries

### DIFF
--- a/c_src/Makefile
+++ b/c_src/Makefile
@@ -1,17 +1,34 @@
 LINUX=$(shell uname | grep Linux | wc -l | xargs echo)
-DEPS=../deps
+DEPS:=../deps
+
+#
+# In the event we have a system zeromq, we can skip this whole build process and use that
+#
+ifndef ZEROMQ_PREFIX
+# poor man's realpath
+#ZEROMQ_PREFIX := $(shell readlink -f "$(DEPS)/local")
+ZEROMQ_PREFIX := $(abspath $(DEPS)/local)
+LOCAL_ZEROMQ=libzmq.a
+endif
+
+
+ZMQ_FLAGS_BASE = --with-libsodium=$(ZEROMQ_PREFIX) --prefix $(ZEROMQ_PREFIX)
 
 ifeq ($(LINUX),1)
-ZMQ_FLAGS=--with-pic --with-pgm
+ZMQ_FLAGS=--with-pic --with-pgm $(ZMQ_FLAGS_BASE)
 else
-ZMQ_FLAGS=
+ZMQ_FLAGS=$(ZMQ_FLAGS_BASE)
 endif
 
 ifndef ZEROMQ_VERSION
 ZEROMQ_VERSION=4.0.5
 endif
 
-all: $(DEPS)/zeromq4/src/.libs/libzmq.a
+ifndef LIBSODIUM_VERSION
+LIBSODIUM_VERSION=1.0.2
+endif
+
+all: $(LOCAL_ZEROMQ)
 
 clean:
 	if test -e $(DEPS)/zeromq4/Makefile; then \
@@ -19,14 +36,45 @@ clean:
 	else \
 		true; \
 	fi
+	if test -e $(DEPS)/libsodium/Makefile; then \
+		cd $(DEPS)/libsodium; make clean;\
+	else \
+		true; \
+	fi
+	rm -rf $(DEPS)/local
 
 distclean:
 	@rm -rf $(DEPS)
 
-$(DEPS)/zeromq4:
+$(DEPS):
 	@mkdir -p $(DEPS)
-	@curl http://download.zeromq.org/zeromq-$(ZEROMQ_VERSION).tar.gz -o $(DEPS)/zeromq-$(ZEROMQ_VERSION).tar.gz
-	@cd $(DEPS) && tar xzvfp zeromq-$(ZEROMQ_VERSION).tar.gz && mv zeromq-$(ZEROMQ_VERSION) zeromq4
 
-$(DEPS)/zeromq4/src/.libs/libzmq.a: $(DEPS)/zeromq4
-	@cd $(DEPS)/zeromq4 && ./configure $(ZMQ_FLAGS) && make
+# Libzmq
+$(DEPS)/zeromq-$(ZEROMQ_VERSION).tar.gz: $(DEPS)
+	@echo downloading zeromq-$(ZEROMQ_VERSION)
+	@curl http://download.zeromq.org/zeromq-$(ZEROMQ_VERSION).tar.gz -o $(DEPS)/zeromq-$(ZEROMQ_VERSION).tar.gz	
+
+$(DEPS)/zeromq4: $(DEPS)/zeromq-$(ZEROMQ_VERSION).tar.gz
+	@mkdir -p $(DEPS)/zeromq4
+	@cd $(DEPS) && tar xzfp zeromq-$(ZEROMQ_VERSION).tar.gz -C zeromq4 --strip-components=1
+
+$(ZEROMQ_PREFIX)/lib/libzmq.a: $(DEPS)/zeromq4 $(ZEROMQ_PREFIX)/lib/libsodium.a
+	cd $(DEPS)/zeromq4 && ./configure $(ZMQ_FLAGS) && make && make install
+
+libzmq.a: $(ZEROMQ_PREFIX)/lib/libzmq.a
+
+
+# Libsodium
+$(DEPS)/libsodium-$(LIBSODIUM_VERSION).tgz: $(DEPS)
+	@echo downloading libsodium-$(LIBSODIUM_VERSION)
+	@curl https://github.com/jedisct1/libsodium/tarball/$(LIBSODIUM_VERSION) -o $(DEPS)/libsodium-$(LIBSODIUM_VERSION).tgz -L
+
+$(DEPS)/libsodium: $(DEPS)/libsodium-$(LIBSODIUM_VERSION).tgz
+	@mkdir -p $(DEPS)/libsodium
+	@tar xzfp $(DEPS)/libsodium-$(LIBSODIUM_VERSION).tgz -C $(DEPS)/libsodium --strip-components=1
+
+$(ZEROMQ_PREFIX)/lib/libsodium.a: $(DEPS)/libsodium
+	cd $(DEPS)/libsodium && ./autogen.sh && ./configure --prefix $(ZEROMQ_PREFIX) && make && make install
+
+libsodium.a: $(ZEROMQ_PREFIX)/lib/libsodium.a
+

--- a/c_src/Makefile
+++ b/c_src/Makefile
@@ -50,7 +50,7 @@ $(DEPS):
 	@mkdir -p $(DEPS)
 
 # Libzmq
-$(DEPS)/zeromq-$(ZEROMQ_VERSION).tar.gz: $(DEPS)
+$(DEPS)/zeromq-$(ZEROMQ_VERSION).tar.gz: | $(DEPS)
 	@echo downloading zeromq-$(ZEROMQ_VERSION)
 	@curl http://download.zeromq.org/zeromq-$(ZEROMQ_VERSION).tar.gz -o $(DEPS)/zeromq-$(ZEROMQ_VERSION).tar.gz	
 
@@ -65,7 +65,7 @@ libzmq.a: $(ZEROMQ_PREFIX)/lib/libzmq.a
 
 
 # Libsodium
-$(DEPS)/libsodium-$(LIBSODIUM_VERSION).tgz: $(DEPS)
+$(DEPS)/libsodium-$(LIBSODIUM_VERSION).tgz: | $(DEPS)
 	@echo downloading libsodium-$(LIBSODIUM_VERSION)
 	@curl https://github.com/jedisct1/libsodium/tarball/$(LIBSODIUM_VERSION) -o $(DEPS)/libsodium-$(LIBSODIUM_VERSION).tgz -L
 

--- a/rebar.config
+++ b/rebar.config
@@ -1,9 +1,12 @@
 {erl_opts, [debug_info, warnings_as_errors]}.
 
+
 {port_env,
- [{"DRV_LDFLAGS","deps/zeromq4/src/.libs/libzmq.a -shared $ERL_LDFLAGS -lstdc++"},
-  {"darwin", "DRV_LDFLAGS", "deps/zeromq4/src/.libs/libzmq.a -bundle -flat_namespace -undefined suppress $ERL_LDFLAGS"},
-  {"DRV_CFLAGS","-Ic_src -Ideps/zeromq4/include -g -Wall -fPIC $ERL_CFLAGS"}]}.
+ [{"DRV_LDFLAGS","-L${ZEROMQ_PREFIX}/lib -L${PWD}/deps/local/lib -lsodium -lzmq ${DRV_LDFLAGS} -lstdc++"},
+%% -rpath is a gnu ld specific option; perhaps -R might be better and allow this to be hoisted
+  {"linux", "DRV_LDFLAGS", "-Wl,-rpath=${ZEROMQ_PREFIX}/lib -Wl,-rpath=${PWD}/deps/local/lib $DRV_LDFLAGS"},
+%%  {"darwin", "DRV_LDFLAGS", "-L$ZEROMQ_PREFIX/lib -Ldeps/local/lib -lsodium -lzmq $DRV_LDFLAGS"},
+  {"DRV_CFLAGS","-Ic_src -I$ZEROMQ_PREFIX/include -Ideps/local/include $DRV_CFLAGS"}]}.
 
 {port_specs, [{"priv/erlzmq_drv.so", ["c_src/*.c"]}]}.
 


### PR DESCRIPTION
Add libsodium support to download path.
Add ZEROMQ_PREFIX path to support vendor zeromq if desired.
Cleanup makefile and break into finer grained pieces to save
download steps.
