### PR TITLE
Fix download URLs for zeromq and libsodium

### DIFF
--- a/c_src/Makefile
+++ b/c_src/Makefile
@@ -24,9 +24,13 @@ ifndef ZEROMQ_VERSION
 ZEROMQ_VERSION=4.0.5
 endif
 
+ZEROMQ_URL=https://archive.org/download/zeromq_$(ZEROMQ_VERSION)/zeromq-$(ZEROMQ_VERSION).tar.gz
+
 ifndef LIBSODIUM_VERSION
-LIBSODIUM_VERSION=1.0.2
+LIBSODIUM_VERSION=1.0.3
 endif
+
+LIBSODIUM_URL=https://github.com/jedisct1/libsodium/tarball/$(LIBSODIUM_VERSION)
 
 all: $(LOCAL_ZEROMQ)
 
@@ -51,8 +55,8 @@ $(DEPS):
 
 # Libzmq
 $(DEPS)/zeromq-$(ZEROMQ_VERSION).tar.gz: | $(DEPS)
-	@echo downloading zeromq-$(ZEROMQ_VERSION)
-	@curl http://download.zeromq.org/zeromq-$(ZEROMQ_VERSION).tar.gz -o $(DEPS)/zeromq-$(ZEROMQ_VERSION).tar.gz	
+	@echo downloading zeromq-$(ZEROMQ_VERSION) from $(ZEROMQ_URL)
+	@curl -L $(ZEROMQ_URL) -o $(DEPS)/zeromq-$(ZEROMQ_VERSION).tar.gz
 
 $(DEPS)/zeromq4: $(DEPS)/zeromq-$(ZEROMQ_VERSION).tar.gz
 	@mkdir -p $(DEPS)/zeromq4
@@ -66,8 +70,8 @@ libzmq.a: $(ZEROMQ_PREFIX)/lib/libzmq.a
 
 # Libsodium
 $(DEPS)/libsodium-$(LIBSODIUM_VERSION).tgz: | $(DEPS)
-	@echo downloading libsodium-$(LIBSODIUM_VERSION)
-	@curl https://github.com/jedisct1/libsodium/tarball/$(LIBSODIUM_VERSION) -o $(DEPS)/libsodium-$(LIBSODIUM_VERSION).tgz -L
+	@echo downloading libsodium-$(LIBSODIUM_VERSION) from $(LIBSODIUM_URL)
+	@curl -L $(LIBSODIUM_URL) -o $(DEPS)/libsodium-$(LIBSODIUM_VERSION).tgz
 
 $(DEPS)/libsodium: $(DEPS)/libsodium-$(LIBSODIUM_VERSION).tgz
 	@mkdir -p $(DEPS)/libsodium
@@ -77,4 +81,3 @@ $(ZEROMQ_PREFIX)/lib/libsodium.a: $(DEPS)/libsodium
 	cd $(DEPS)/libsodium && ./autogen.sh && ./configure --prefix $(ZEROMQ_PREFIX) && make && make install
 
 libsodium.a: $(ZEROMQ_PREFIX)/lib/libsodium.a
-

--- a/c_src/Makefile
+++ b/c_src/Makefile
@@ -2,13 +2,14 @@ LINUX=$(shell uname | grep Linux | wc -l | xargs echo)
 DEPS:=../deps
 
 #
-# In the event we have a system zeromq, we can skip this whole build process and use that
+# In the event we have a system zeromq, we can skip this whole build
+# process and use that
 #
-ifndef ZEROMQ_PREFIX
-# poor man's realpath
-#ZEROMQ_PREFIX := $(shell readlink -f "$(DEPS)/local")
+ifdef ZEROMQ_PREFIX
+ALL_DEPS=print_prefix
+else
 ZEROMQ_PREFIX := $(abspath $(DEPS)/local)
-LOCAL_ZEROMQ=libzmq.a
+ALL_DEPS=print_prefix libzmq.a
 endif
 
 
@@ -32,7 +33,7 @@ endif
 
 LIBSODIUM_URL=https://github.com/jedisct1/libsodium/tarball/$(LIBSODIUM_VERSION)
 
-all: $(LOCAL_ZEROMQ)
+all: $(ALL_DEPS)
 
 clean:
 	if test -e $(DEPS)/zeromq4/Makefile; then \
@@ -49,6 +50,9 @@ clean:
 
 distclean:
 	@rm -rf $(DEPS)
+
+print_prefix:
+	@echo "Building with ZEROMQ_PREFIX=$(ZEROMQ_PREFIX)"
 
 $(DEPS):
 	@mkdir -p $(DEPS)

--- a/rebar.config
+++ b/rebar.config
@@ -4,6 +4,9 @@
  [{"DRV_LDFLAGS","-L${ZEROMQ_PREFIX}/lib -Ldeps/local/lib -lsodium -lzmq ${DRV_LDFLAGS} -lstdc++"},
   %% -rpath is a gnu ld specific option; perhaps -R might be better and allow this to be hoisted
   {"linux", "DRV_LDFLAGS", "-Wl,-rpath=${ZEROMQ_PREFIX}/lib -Wl,-rpath=${PWD}/deps/local/lib $DRV_LDFLAGS"},
+  %% rebar 2.6.2 is setting -flat_namespace -undefined suppress
+  %% which was causing link errors on OS X 10.11
+  {"darwin", "LDFLAGS", "-arch x86_64"},
   {"DRV_CFLAGS","-Ic_src -I${ZEROMQ_PREFIX}/include -Ideps/local/include $DRV_CFLAGS"}]}.
 
 {port_specs, [{"priv/erlzmq_drv.so", ["c_src/*.c"]}]}.

--- a/rebar.config
+++ b/rebar.config
@@ -3,10 +3,10 @@
 
 {port_env,
  [{"DRV_LDFLAGS","-L${ZEROMQ_PREFIX}/lib -L${PWD}/deps/local/lib -lsodium -lzmq ${DRV_LDFLAGS} -lstdc++"},
-%% -rpath is a gnu ld specific option; perhaps -R might be better and allow this to be hoisted
+  %% -rpath is a gnu ld specific option; perhaps -R might be better and allow this to be hoisted
   {"linux", "DRV_LDFLAGS", "-Wl,-rpath=${ZEROMQ_PREFIX}/lib -Wl,-rpath=${PWD}/deps/local/lib $DRV_LDFLAGS"},
-%%  {"darwin", "DRV_LDFLAGS", "-L$ZEROMQ_PREFIX/lib -Ldeps/local/lib -lsodium -lzmq $DRV_LDFLAGS"},
-  {"DRV_CFLAGS","-Ic_src -I$ZEROMQ_PREFIX/include -Ideps/local/include $DRV_CFLAGS"}]}.
+  {"darwin", "DRV_LDFLAGS", "-L${ZEROMQ_PREFIX}/lib -Ldeps/local/lib -lsodium -lzmq $DRV_LDFLAGS"},
+  {"DRV_CFLAGS","-Ic_src -I${ZEROMQ_PREFIX}/include -Ideps/local/include $DRV_CFLAGS"}]}.
 
 {port_specs, [{"priv/erlzmq_drv.so", ["c_src/*.c"]}]}.
 

--- a/rebar.config
+++ b/rebar.config
@@ -1,11 +1,9 @@
 {erl_opts, [debug_info, warnings_as_errors]}.
 
-
 {port_env,
- [{"DRV_LDFLAGS","-L${ZEROMQ_PREFIX}/lib -L${PWD}/deps/local/lib -lsodium -lzmq ${DRV_LDFLAGS} -lstdc++"},
+ [{"DRV_LDFLAGS","-L${ZEROMQ_PREFIX}/lib -Ldeps/local/lib -lsodium -lzmq ${DRV_LDFLAGS} -lstdc++"},
   %% -rpath is a gnu ld specific option; perhaps -R might be better and allow this to be hoisted
   {"linux", "DRV_LDFLAGS", "-Wl,-rpath=${ZEROMQ_PREFIX}/lib -Wl,-rpath=${PWD}/deps/local/lib $DRV_LDFLAGS"},
-  {"darwin", "DRV_LDFLAGS", "-L${ZEROMQ_PREFIX}/lib -Ldeps/local/lib -lsodium -lzmq $DRV_LDFLAGS"},
   {"DRV_CFLAGS","-Ic_src -I${ZEROMQ_PREFIX}/include -Ideps/local/include $DRV_CFLAGS"}]}.
 
 {port_specs, [{"priv/erlzmq_drv.so", ["c_src/*.c"]}]}.


### PR DESCRIPTION
- libsodium 1.0.2 isn't provided by the upstream anymore, try 1.0.3
- zeromq's url was issuing a redirect that we weren't following

Signed-off-by: Steven Danna steve@chef.io
